### PR TITLE
(ASC-136) added cinder tests

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import testinfra.utils.ansible_runner
 
@@ -30,3 +31,27 @@ def test_ntp_service(host):
     s = host.service(ntp_daemon)
     assert s.is_running
     assert s.is_enabled
+
+
+def test_cinder_service(host):
+    cmd = "sudo bash -c \"source /root/openrc; cinder service-list\""
+    output = host.run(cmd)
+    assert ("cinder-volume" in output.stdout)
+
+
+def test_cinder_lvm_volume(host):
+    cmd = "sudo bash -c \"source /root/openrc; " \
+          "pushd /opt/openstack-ansible; " \
+          "ansible storage_hosts -m shell -a 'vgs cinder-volumes'\""
+    output = host.run(cmd)
+    assert re.search("cinder-volumes\s+[0-9]*\s+[0-9]*\s+", output.stdout)
+
+
+def test_cinder_volume_group(host):
+    cmd = "sudo bash -c \"source /root/openrc; " \
+          "pushd /opt/openstack-ansible; " \
+          "ansible cinder_volume -m shell -a " \
+          "'grep volume_group /etc/cinder/cinder.conf'\""
+    output = host.run(cmd)
+    assert ("SUCCESS" in output.stdout)
+    assert ("volume_group=cinder-volumes" in output.stdout)


### PR DESCRIPTION
This PR adds three basic tests for Cinder:
1. Test 1: Verify cinder service is running
2. Test 2: Verify there is at least a cinder-volume 
3. Test 3: Verify that cinder volume group is created successfully