### PR TITLE
Add Support for Child Groups

### DIFF
--- a/templates/molecule.yml.j2
+++ b/templates/molecule.yml.j2
@@ -12,11 +12,11 @@ lint:
   name: yamllint
 platforms:
 {% for host in hosts.keys()|sort %}
-  - name: {{host}}
-{% if hosts[host]|length > 1 %}
+  - name: {{ host }}
+{% if hosts[host]|length > 0 %}
     groups:
 {% for group in hosts[host]|sort %}
-      - {{group}}
+      - {{ group }}
 {% endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Allow moleculerize.py to add hosts to groups composed of other groups. Also, I changed the line endings for moleculerize.py to Unix LF style.